### PR TITLE
Fix: Conflict Lombok vs JPA

### DIFF
--- a/services/user-service/src/main/java/com/hieunn/user_service/models/User.java
+++ b/services/user-service/src/main/java/com/hieunn/user_service/models/User.java
@@ -72,4 +72,8 @@ public class User {
     @Column(name = "updated_at", nullable = false)
     @JsonFormat(pattern = "dd/MM/yyyy HH:mm:ss")
     LocalDateTime updatedAt;
+
+    public boolean getIsStudent() {
+        return this.isStudent;
+    }
 }

--- a/services/user-service/src/main/java/com/hieunn/user_service/repositories/UserRepository.java
+++ b/services/user-service/src/main/java/com/hieunn/user_service/repositories/UserRepository.java
@@ -15,5 +15,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
-    List<User> findAllByStudentTrue();
+    List<User> findAllByIsStudentTrue();
 }

--- a/services/user-service/src/main/java/com/hieunn/user_service/scheduler/StudentStatusScheduler.java
+++ b/services/user-service/src/main/java/com/hieunn/user_service/scheduler/StudentStatusScheduler.java
@@ -21,7 +21,7 @@ public class StudentStatusScheduler {
     @Scheduled(cron = "0 0 0 * * ?")
     @Transactional
     public void disableExpiredStudents() {
-        List<User> users = userRepository.findAllByStudentTrue();
+        List<User> users = userRepository.findAllByIsStudentTrue();
         LocalDate today = LocalDate.now();
         for (User user : users) {
             if (user.getStudentExpiredDate() != null &&


### PR DESCRIPTION
This pull request introduces changes to the `User` model, repository, and a scheduler in the `user-service` module to improve naming consistency and functionality related to the `isStudent` property. The most important changes include renaming a repository method for clarity, updating its usage in the scheduler, and adding a getter method for the `isStudent` field in the `User` model.

### Changes to improve naming consistency:

* **Repository method renaming**: Renamed `findAllByStudentTrue` to `findAllByIsStudentTrue` in `UserRepository` to better align with the `isStudent` field name. (`services/user-service/src/main/java/com/hieunn/user_service/repositories/UserRepository.java`)

* **Scheduler method update**: Updated the `disableExpiredStudents` method in `StudentStatusScheduler` to use the renamed repository method `findAllByIsStudentTrue`. (`services/user-service/src/main/java/com/hieunn/user_service/scheduler/StudentStatusScheduler.java`)

### Changes to enhance functionality:

* **Added getter for `isStudent`**: Introduced a `getIsStudent` method in the `User` model to provide access to the `isStudent` field. (`services/user-service/src/main/java/com/hieunn/user_service/models/User.java`)