### PR TITLE
fix: public api

### DIFF
--- a/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/configs/GatewayConfig.java
+++ b/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/configs/GatewayConfig.java
@@ -14,17 +14,22 @@ public class GatewayConfig {
     private final String API_PREFIX = "/api";
     private final String STATION_SERVICE = "lb://station-service";
     private final String TICKET_SERVICE = "lb://ticket-service";
+    private final String ORDER_SERVICE = "lb://order-service";
 
     @Bean
     public RouteLocator routeLocator(RouteLocatorBuilder builder) {
         return builder.routes()
                 .route("station_service_route", r -> r
                         .path(API_PREFIX + "/stations/**", API_PREFIX + "/schedules/**", API_PREFIX + "/routes/**")
-                        .uri("http://localhost:4004"))
+                        .uri(STATION_SERVICE))
 
                 .route("ticket_service_route", r -> r
                         .path(API_PREFIX + "/ts/**")
                         .uri(TICKET_SERVICE))
+
+                .route("order_service_route", r -> r
+                        .path(API_PREFIX + "/user/orders/**")
+                        .uri(ORDER_SERVICE))
 
                 .route("user_service_route", r -> r
                         .path(API_PREFIX + "/users/**")

--- a/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/filters/JwtAuthenticationFilter.java
+++ b/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/filters/JwtAuthenticationFilter.java
@@ -63,7 +63,7 @@ public class JwtAuthenticationFilter implements WebFilter {
             "/api/routes/**",
             //ticket
             "/api/ts/**",
-            "/user/orders/**"
+            "/api/user/orders/**"
 
     );
 

--- a/services/order-service/src/main/java/com/example/cronjob/Controller/OrderController.java
+++ b/services/order-service/src/main/java/com/example/cronjob/Controller/OrderController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/user/orders")
+@RequestMapping("/api/user/orders")
 @Tag(name = "Order Management", description = "APIs for managing user orders")
 public class OrderController {
     @Autowired

--- a/services/order-service/src/main/resources/application.yml
+++ b/services/order-service/src/main/resources/application.yml
@@ -5,12 +5,12 @@ spring:
   cloud:
     discovery:
       enabled: true
+      eureka:
+        client:
+          serviceUrl:
+            defaultZone: http://eureka:8761/eureka/
 
   profiles:
     active: dev
 
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://eureka:8761/eureka/ # Eureka Server URL
 

--- a/services/station-service/src/main/resources/application.yml
+++ b/services/station-service/src/main/resources/application.yml
@@ -5,11 +5,11 @@ spring:
   cloud:
     discovery:
       enabled: true
+      eureka:
+        client:
+          serviceUrl:
+            defaultZone: http://eureka:8761/eureka/
 
   profiles:
     active: dev
 
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://eureka:8761/eureka/ # Eureka Server URL

--- a/services/ticket-service/src/main/resources/application.yml
+++ b/services/ticket-service/src/main/resources/application.yml
@@ -10,14 +10,15 @@ spring:
   cloud:
     discovery:
       enabled: true
+      eureka:
+        client:
+          serviceUrl:
+            defaultZone: http://eureka:8761/eureka/
 
   profiles:
     active: dev
 
-eureka:
-  client:
-    serviceUrl:
-      defaultZone: http://eureka:8761/eureka/ # Eureka Server URL
+
 
 #app:
 #  ticket:


### PR DESCRIPTION
This pull request introduces changes to integrate a new `order-service` into the gateway, update API paths for consistency, and refactor service discovery configurations to align with Spring Cloud standards. The most important changes include adding routing for the `order-service`, updating API paths to include the `/api` prefix, and modifying service discovery configurations to use the `spring.cloud.discovery` structure.

### Gateway Configuration Updates:
* Added a new route for `order-service` in the `GatewayConfig` class, mapping `/api/user/orders/**` to the `order-service`.
* Updated the URI for `station-service` in the gateway to use the `STATION_SERVICE` constant instead of a hardcoded localhost URL.

### API Path Standardization:
* Updated the API path for user orders in the `JwtAuthenticationFilter` to include the `/api` prefix, ensuring consistency across services.
* Changed the `@RequestMapping` path in `OrderController` to `/api/user/orders` to reflect the updated API path.

### Service Discovery Refactor:
* Refactored the service discovery configuration in `application.yml` files for `order-service`, `station-service`, and `ticket-service` to use `spring.cloud.discovery.eureka.client.serviceUrl.defaultZone` instead of the deprecated `eureka.client.serviceUrl.defaultZone`. [[1]](diffhunk://#diff-de38790fb9c33169172c1b094eef11113b4c37a81d9e4290b5f80619765ac050R8-L15) [[2]](diffhunk://#diff-8f33122ac05cdc739e24a8ef5ca9a0cdd0a4e3922d8b454f01dd731b2a053b16R8-L15) [[3]](diffhunk://#diff-65dfc66ccb851ed4c477f5b839837c07aaf575fc70af4fb4ba6ee62c704efabcR13-R21)