### PR TITLE
add new api generate qr

### DIFF
--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/controller/TicketController.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/controller/TicketController.java
@@ -12,6 +12,7 @@ import org.alfred.ticketservice.model.enums.TicketStatus;
 import org.alfred.ticketservice.service.TicketService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
@@ -134,5 +135,13 @@ public class TicketController {
         log.info("Request to generate QR code data for: {}", ticketCode);
         byte[] qrCodeData = ticketService.generateQrCodeData(ticketCode);
         return ResponseEntity.ok(ApiResponse.success(qrCodeData, "QR code data generated successfully"));
+    }
+
+    @GetMapping(value = "/qr", produces = MediaType.IMAGE_PNG_VALUE)
+    @PreAuthorize("hasAuthority('ROLE_CUSTOMER')")
+    public ResponseEntity<byte[]> getQrCodeImage(@RequestParam @NotBlank String ticketCode) {
+        log.info("Request to get QR code image for: {}", ticketCode);
+        byte[] qrCodeImage = ticketService.generateQrCodeData(ticketCode);
+        return ResponseEntity.ok().contentType(MediaType.IMAGE_PNG).body(qrCodeImage);
     }
 }


### PR DESCRIPTION
This pull request introduces a new endpoint in the `TicketController` to retrieve QR code images in PNG format. It also includes a minor import addition to support the new functionality.

### New endpoint for QR code images:

* Added a `GET /qr` endpoint in `TicketController` to serve QR code images as PNGs. The endpoint is secured with a `ROLE_CUSTOMER` authority check and logs the ticket code for which the QR code image is requested. (`services/ticket-service/src/main/java/org/alfred/ticketservice/controller/TicketController.java`, [services/ticket-service/src/main/java/org/alfred/ticketservice/controller/TicketController.javaR139-R146](diffhunk://#diff-47d6080d74f064fda924acaf23c107abc85814e406a709f134194feb78fa99f8R139-R146))

### Supporting changes:

* Imported `MediaType` to specify the content type for the new QR code image endpoint. (`services/ticket-service/src/main/java/org/alfred/ticketservice/controller/TicketController.java`, [services/ticket-service/src/main/java/org/alfred/ticketservice/controller/TicketController.javaR15](diffhunk://#diff-47d6080d74f064fda924acaf23c107abc85814e406a709f134194feb78fa99f8R15))