### PR TITLE
add new api get fare, public some api

### DIFF
--- a/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/configs/GatewayConfig.java
+++ b/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/configs/GatewayConfig.java
@@ -21,7 +21,7 @@ public class GatewayConfig {
         return builder.routes()
                 .route("station_service_route", r -> r
                         .path(API_PREFIX + "/stations/**", API_PREFIX + "/schedules/**", API_PREFIX + "/routes/**")
-                        .uri(STATION_SERVICE))
+                        .uri("http://localhost:4004"))
 
                 .route("ticket_service_route", r -> r
                         .path(API_PREFIX + "/ts/**")

--- a/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/configs/SecurityConfig.java
+++ b/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/configs/SecurityConfig.java
@@ -18,7 +18,24 @@ public class SecurityConfig {
             "/actuator/**",
             "/webjars/**",
             "/api/v1/auth/**",
-            "/api/auth/**"
+            "/api/auth/**",
+            "/api/ts/fare-matrices/{id}",
+            "/api/ts/fare-matrices",
+            "/api/ts/fare-matrices/by-station/{stationId}",
+            "/api/ts/fare-matrices/get-fare",
+            "/api/ts/ticket-types/{id}",
+            "/api/ts/ticket-types",
+            "/api/routes",
+            "/api/routes/{id}",
+            "/api/routes/search",
+            "/api/routes/code/{routeCode}",
+            "/api/stations",
+            "/api/stations/{id}",
+            "/api/stations/search",
+            "api/stations/route/{routeId}",
+            "/api/schedules",
+            "/api/schedules/{id}",
+            "/api/schedules/station/{stationId}"
     };
 
     @Bean

--- a/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/filters/JwtAuthenticationFilter.java
+++ b/services/gateway-service/src/main/java/org/com/hcmurs/gatewayservice/filters/JwtAuthenticationFilter.java
@@ -78,6 +78,7 @@ public class JwtAuthenticationFilter implements WebFilter {
             "/api/ts/fare-matrices/{id}",
             "/api/ts/fare-matrices",
             "/api/ts/fare-matrices/by-station/{stationId}",
+            "/api/ts/fare-matrices/get-fare",
             "/api/ts/ticket-types/{id}",
             "/api/ts/ticket-types",
             "api/payment/callback/**",

--- a/services/station-service/src/main/java/com/example/stationservice/config/SecurityConfig.java
+++ b/services/station-service/src/main/java/com/example/stationservice/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
 //                        .requestMatchers("/api/v1/accounts/login","/api/v1/accounts/register").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**","swagger-ui.html/**").permitAll()
                         .requestMatchers("/api/routes","/api/routes/{id}","/api/routes/search","/api/routes/code/{routeCode}").permitAll()
-                        .requestMatchers("/api/stations","/api/stations/{id}","/api/stations/search","api/stations/route/{routeId}").permitAll()
+                        .requestMatchers("/api/stations","/api/stations/{id}","/api/stations/search","/api/stations/route/{routeId}").permitAll()
                         .requestMatchers("/api/schedules","/api/schedules/{id}","/api/schedules/station/{stationId}").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/client/StationClient.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/client/StationClient.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "station-service", path = "/api/stations")
 public interface StationClient {
-    @GetMapping("/stations/{id}")
+    @GetMapping("/{id}")
     ApiResponse<StationResponse> getStationById(@PathVariable("id") Long id);
 
     @GetMapping("/check-line")

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/config/SecurityConfig.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/ts/fare-matrices/{id}","/api/ts/fare-matrices","/api/ts/fare-matrices/by-station/{stationId}").permitAll()
+                        .requestMatchers("/api/ts/fare-matrices/{id}","/api/ts/fare-matrices","/api/ts/fare-matrices/by-station/{stationId}","/api/ts/fare-matrices/get-fare").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**","swagger-ui.html/**")
                                 .permitAll()
                         .requestMatchers("/api/ts/ticket-types/{id}","/api/ts/ticket-types").permitAll()

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/controller/FareMatrixController.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/controller/FareMatrixController.java
@@ -83,4 +83,11 @@ public class FareMatrixController {
         return ResponseEntity.ok(ApiResponse.success(isValid,
                 isValid ? "Station is valid for this fare matrix" : "Station is not valid for this fare matrix"));
     }
+
+    @GetMapping("/get-fare")
+    public ResponseEntity<ApiResponse<FareMatrixResponse>> getFare(
+            @RequestBody @Valid FindFareRequest fareRequest) {
+        FareMatrixResponse fare = fareMatrixService.getFareMatrixByStations(fareRequest);
+        return ResponseEntity.ok(ApiResponse.success(fare, "Fare retrieved successfully"));
+    }
 }

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/dto/fare_matrix/FindFareRequest.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/dto/fare_matrix/FindFareRequest.java
@@ -1,0 +1,15 @@
+package org.alfred.ticketservice.dto.fare_matrix;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record FindFareRequest(
+        @NotNull(message = "Start station ID is required")
+        @PositiveOrZero(message = "Start station ID must be valid")
+        Long startStationId,
+
+        @NotNull(message = "End station ID is required")
+        @PositiveOrZero(message = "End station ID must be valid")
+        Long endStationId
+) {
+}

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/service/FareMatrixService.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/service/FareMatrixService.java
@@ -18,4 +18,6 @@ public interface FareMatrixService {
     List<FareMatrixResponse> getFareMatricesByStartStationId(Long startStationId);
 
     boolean isStationInFareMatrix(Long stationId, Long fareMatrixId);
+
+    FareMatrixResponse getFareMatrixByStations(FindFareRequest request);
 }

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/service/FareMatrixServiceImpl.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/service/FareMatrixServiceImpl.java
@@ -95,6 +95,23 @@ public class FareMatrixServiceImpl implements FareMatrixService{
         return stationClient.checkStationOnLine(startStationId,endStationId, stationId).getData();
     }
 
+    @Override
+    public FareMatrixResponse getFareMatrixByStations(FindFareRequest findFareRequest) {
+        Long startStationId = findFareRequest.startStationId();
+        Long endStationId = findFareRequest.endStationId();
+        if (stationClient.getStationById(startStationId).getData() == null) {
+            throw new EntityNotFoundException("Start station not found with id: " + startStationId);
+        }
+        if (stationClient.getStationById(endStationId).getData() == null) {
+            throw new EntityNotFoundException("End station not found with id: " + endStationId);
+        }
+        FareMatrix fareMatrix = fareMatrixRepository.findByStartStationIdAndEndStationId(startStationId, endStationId);
+        if (fareMatrix == null) {
+            throw new EntityNotFoundException("Fare matrix not found for the given station pair");
+        }
+        return mapToResponse(fareMatrix);
+    }
+
     private FareMatrixResponse mapToResponse(FareMatrix fareMatrix) {
         return FareMatrixResponse.builder()
                 .fareMatrixId(fareMatrix.getFareMatrixId())


### PR DESCRIPTION
This pull request introduces multiple changes across the gateway, station service, and ticket service to enhance routing, security configurations, and fare matrix functionality. The most significant updates include the addition of a new endpoint for retrieving fare information, adjustments to security configurations, and improvements to service routing. Below is a summary of the most important changes grouped by theme.

### Fare Matrix Enhancements:
* Added a new endpoint `/api/ts/fare-matrices/get-fare` in `FareMatrixController` to retrieve fare details based on start and end stations. This includes a new `FindFareRequest` DTO for input validation and a corresponding service method implementation. [[1]](diffhunk://#diff-804a469ba6231183a15e5791488d312a11c2ee59a1adc299ad28de4ec2e6a3d3R86-R92) [[2]](diffhunk://#diff-95e652b242cf04f57269d3bed2e0726ddcdb653c8f0f9bff8db8ed44521dbc4eR1-R15) [[3]](diffhunk://#diff-8a658bd14bdaa6c4133297ed0b2d06d6304cd9d2553feb8a24861d24bcfbd7b7R21-R22) [[4]](diffhunk://#diff-9ab2e1f388da1e6e787605f4581385afe8ee8e35f273b61f653456b1c2e78ab1R98-R114)

### Security Configuration Updates:
* Updated the security configuration in `gateway-service` to allow public access to multiple new endpoints, including fare matrices, ticket types, routes, stations, and schedules.
* Adjusted the `station-service` and `ticket-service` security configurations to ensure consistent endpoint access rules, including permitting the new `/api/ts/fare-matrices/get-fare` endpoint. [[1]](diffhunk://#diff-9c9cb5ffbc2298b95c08deb75af8179aaa64b5ea0cb27125da9c1acec4cce712L36-R36) [[2]](diffhunk://#diff-053779cb0f0aa930d9d1524cc1bb49409d6b485159ab19c50a73c11b87fc36a8L37-R37)

### Routing Adjustments:
* Modified the station service route in `GatewayConfig` to use `http://localhost:4004` instead of the `STATION_SERVICE` constant.
* Fixed a typo in the `StationClient` Feign client path to remove the redundant `/stations` prefix.