### PR TITLE
update api update from ticket service

### DIFF
--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/controller/FareMatrixController.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/controller/FareMatrixController.java
@@ -49,11 +49,12 @@ public class FareMatrixController {
         );
     }
 
-    @PutMapping("/update")
+    @PutMapping("/update/{fareMatrixId}")
     @PreAuthorize("hasAuthority('ROLE_ADMIN') or hasAuthority('ROLE_STAFF')")
-    public ResponseEntity<ApiResponse<FareMatrixResponse>> updateFareMatrix(@Valid @RequestBody FareMatrixUpdateRequest request) {
+    public ResponseEntity<ApiResponse<FareMatrixResponse>> updateFareMatrix(@Valid @RequestBody FareMatrixRequest request,
+                                                                           @PathVariable Long fareMatrixId)  {
         log.info("Request to update fare matrix with ID: {}", request.fareMatrixId());
-        FareMatrixResponse updatedFareMatrix = fareMatrixService.updateFareMatrix(request);
+        FareMatrixResponse updatedFareMatrix = fareMatrixService.updateFareMatrix(request,fareMatrixId);
         return ResponseEntity.ok(ApiResponse.success(updatedFareMatrix, "Fare matrix updated successfully"));
     }
 

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/controller/TicketTypeController.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/controller/TicketTypeController.java
@@ -49,11 +49,12 @@ public class TicketTypeController {
         );
     }
 
-    @PutMapping("/update")
+    @PutMapping("/update/{id}")
     @PreAuthorize("hasAuthority('ROLE_ADMIN')")
-    public ResponseEntity<ApiResponse<TicketTypeResponse>> updateTicketType(@Valid @RequestBody TicketTypeRequest request) {
-        log.info("Request to update ticket type with ID: {}", request.ticketTypeId());
-        TicketTypeResponse updatedTicketType = ticketTypeService.updateTicketType(request);
+    public ResponseEntity<ApiResponse<TicketTypeResponse>> updateTicketType(@Valid @RequestBody TicketTypeRequest request,
+                                                                           @PathVariable Long id)  {
+        log.info("Request to update ticket type with ID: {}", id);
+        TicketTypeResponse updatedTicketType = ticketTypeService.updateTicketType(request,id);
         return ResponseEntity.ok(ApiResponse.success(updatedTicketType, "Ticket type updated successfully"));
     }
 

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/dto/ticket_type/TicketTypeRequest.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/dto/ticket_type/TicketTypeRequest.java
@@ -5,7 +5,6 @@ package org.alfred.ticketservice.dto.ticket_type;
 
 public record TicketTypeRequest(
                 // Optional for creation, required for updates
-                Long ticketTypeId,
 
                 @NotBlank(message = "Name cannot be empty")
                 @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters")

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/service/FareMatrixService.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/service/FareMatrixService.java
@@ -9,7 +9,7 @@ public interface FareMatrixService {
 
     FareMatrixResponse createFareMatrix(FareMatrixRequest fareMatrix);
 
-    FareMatrixResponse updateFareMatrix(FareMatrixUpdateRequest fareMatrix);
+    FareMatrixResponse updateFareMatrix(FareMatrixRequest fareMatrix, Long id);
 
     void deleteFareMatrix(Long id);
 

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/service/FareMatrixServiceImpl.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/service/FareMatrixServiceImpl.java
@@ -43,12 +43,16 @@ public class FareMatrixServiceImpl implements FareMatrixService{
     }
 
     @Override
-    public FareMatrixResponse updateFareMatrix(FareMatrixUpdateRequest fareMatrix) {
+    public FareMatrixResponse updateFareMatrix(FareMatrixRequest fareMatrix, Long id) {
+        FareMatrix fareMatrixexist = fareMatrixRepository.findByStartStationIdAndEndStationId(
+                fareMatrix.startStationId(), fareMatrix.endStationId());
+        if (fareMatrixexist != null) throw new EntityExistsException("Fare matrix already exists for this station pair");
         FareMatrix fareMatrixEntity = fareMatrixRepository.findById(fareMatrix.fareMatrixId())
                 .orElseThrow(() -> new EntityNotFoundException("Fare matrix not found"));
         fareMatrixEntity.setPrice(fareMatrix.price());
         fareMatrixEntity.setName(fareMatrix.name());
-        fareMatrixEntity.setActive(fareMatrix.isActive());
+        fareMatrixEntity.setStartStationId(fareMatrix.startStationId());
+        fareMatrixEntity.setEndStationId(fareMatrix.endStationId());
         fareMatrixRepository.save(fareMatrixEntity);
         return mapToResponse(fareMatrixEntity);
     }

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/service/TicketTypeService.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/service/TicketTypeService.java
@@ -11,7 +11,7 @@ public interface TicketTypeService {
 
     TicketTypeResponse createTicketType(TicketTypeRequest ticketType);
 
-    TicketTypeResponse updateTicketType(TicketTypeRequest ticketType);
+    TicketTypeResponse updateTicketType(TicketTypeRequest ticketType,Long id);
 
     List<TicketTypeResponse> getAll();
 

--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/service/TicketTypeServiceImpl.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/service/TicketTypeServiceImpl.java
@@ -41,8 +41,8 @@ public class TicketTypeServiceImpl implements TicketTypeService{
     }
 
     @Override
-    public TicketTypeResponse updateTicketType(TicketTypeRequest ticketType) {
-        TicketTypes ticketTypes = ticketTypeRepository.findById(ticketType.ticketTypeId())
+    public TicketTypeResponse updateTicketType(TicketTypeRequest ticketType, Long id) {
+        TicketTypes ticketTypes = ticketTypeRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Ticket type not found"));
         ticketTypes.setName(ticketType.name());
         ticketTypes.setDescription(ticketType.description());


### PR DESCRIPTION
This pull request refactors the update endpoints for both the Fare Matrix and Ticket Type services to improve consistency and clarity. It introduces the use of `@PathVariable` for IDs instead of relying on request body fields, updates the service layer to reflect this change, and removes redundant fields from request DTOs.

### Controller Updates:
* [`FareMatrixController.java`](diffhunk://#diff-804a469ba6231183a15e5791488d312a11c2ee59a1adc299ad28de4ec2e6a3d3L52-R57): Updated the `updateFareMatrix` endpoint to accept `fareMatrixId` as a `@PathVariable` instead of extracting it from the request body.
* [`TicketTypeController.java`](diffhunk://#diff-ab5df71f4ebd12056ea6e1f9e216ef037817f60f15ccbf294f27ab74a5ba6d36L52-R57): Updated the `updateTicketType` endpoint to accept `id` as a `@PathVariable` instead of extracting it from the request body.

### Request DTO Changes:
* [`TicketTypeRequest.java`](diffhunk://#diff-95cfe336405f61ba15ab3102e694b7412853d3b4782c4cef9e8f9ccf1a8fbcb6L8): Removed the `ticketTypeId` field as it is no longer needed in the request body for updates.

### Service Layer Updates:
* `FareMatrixService.java` and `FareMatrixServiceImpl.java`: Updated the `updateFareMatrix` method to accept the ID as a separate parameter and added validation to prevent duplicate fare matrices for the same station pair. [[1]](diffhunk://#diff-8a658bd14bdaa6c4133297ed0b2d06d6304cd9d2553feb8a24861d24bcfbd7b7L12-R12) [[2]](diffhunk://#diff-9ab2e1f388da1e6e787605f4581385afe8ee8e35f273b61f653456b1c2e78ab1L46-R55)
* `TicketTypeService.java` and `TicketTypeServiceImpl.java`: Updated the `updateTicketType` method to accept the ID as a separate parameter. [[1]](diffhunk://#diff-ba93d60ab198330e2ed0fa46eeff0f6d7fa0224b59a5b2a4150287f17b09f94eL14-R14) [[2]](diffhunk://#diff-34d87e49c72f65062c0e1fc6371add91471c8225f38cf493ec25b4da95288051L44-R45)