### PR TITLE
fix type

### DIFF
--- a/services/ticket-service/src/main/java/org/alfred/ticketservice/dto/fare_matrix/FareMatrixResponse.java
+++ b/services/ticket-service/src/main/java/org/alfred/ticketservice/dto/fare_matrix/FareMatrixResponse.java
@@ -9,8 +9,8 @@ public record FareMatrixResponse(
         Long fareMatrixId,
         String name,
         float price,
-        float startStationId,
-        float endStationId,
+        Long startStationId,
+        Long endStationId,
         boolean isActive,
         LocalDateTime createdAt,
         LocalDateTime updatedAt


### PR DESCRIPTION
This pull request includes a type correction in the `FareMatrixResponse` record within the `ticket-service` module. The main change involves updating the data types of two fields to ensure consistency and accuracy.

### Type corrections:

* [`services/ticket-service/src/main/java/org/alfred/ticketservice/dto/fare_matrix/FareMatrixResponse.java`](diffhunk://#diff-9625773c876ec739129b5c9cb6c9b53861b4684ea98a56ae60f1c9b35bdfd8afL12-R13): Updated the `startStationId` and `endStationId` fields from `float` to `Long` to better represent station identifiers as non-decimal values.